### PR TITLE
expanded test clause

### DIFF
--- a/tests/test_approx_umap.py
+++ b/tests/test_approx_umap.py
@@ -15,4 +15,6 @@ def test_not_enough_neigh():
     X = np.random.rand(5, 10)
     aumap = ApproxUMAP(n_neighbors=10)
     emb = aumap.fit_transform(X)
+    emb2 = aumap.transform(X)
     assert emb.shape == (5, 2)
+    assert emb2.shape == (5, 2)


### PR DESCRIPTION
Currently, the transform function fails if the model has been trained on fewer datapoints than the number of neighbors. This clause was not covered by the tests.

Results of new test:
`D:\Python\Python311\Lib\site-packages\umap\umap_.py:2433: UserWarning: n_neighbors is larger than the dataset size; truncating to X.shape[0] - 1
  warn(
Traceback (most recent call last):
  File "d:\Repos\approx-umap\main.py", line 5, in <module>
    test_not_enough_neigh()
  File "d:\Repos\approx-umap\tests\test_approx_umap.py", line 18, in test_not_enough_neigh
    emb2 = aumap.transform(X)
           ^^^^^^^^^^^^^^^^^^
  File "d:\Repos\approx-umap\approx_umap\approx_umap.py", line 127, in transform
    neigh_dist, neigh_ind = self._knn.kneighbors(X, return_distance=True)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Python\Python311\Lib\site-packages\sklearn\neighbors\_base.py", line 835, in kneighbors
    raise ValueError(
ValueError: Expected n_neighbors <= n_samples_fit, but n_neighbors = 10, n_samples_fit = 5, n_samples = 5`